### PR TITLE
downgrade mongodb driver to 1.0, as to run on ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ docker run --rm -it -v $(pwd):/data chesszebra/composer:7.0 install
 The OAuth server requires a public and private key, let's create them:
 
 ```
-openssl genrsa -out private.key 2048
+openssl genrsa -out data/private.key 2048
 openssl rsa -in data/private.key -pubout -out data/public.key
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.0",
         "http-interop/http-middleware": "^0.4.1",
         "league/oauth2-server": "^6.1",
-        "mongodb/mongodb": "^1.2",
+        "mongodb/mongodb": "^1.0",
         "roave/security-advisories": "dev-master",
         "symfony/console": "^3.4",
         "twig/extensions": "^1.5",


### PR DESCRIPTION
I suppose composer.lock should be updated as well?